### PR TITLE
Add photography, manual odering of sidebar elements, update talks

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -28,7 +28,7 @@
     <nav class="sidebar-nav">
       <ul>
         <li>
-          <a class="sidebar-nav-item" href="{{ site.baseurl }}/">News</a>
+          <a class="sidebar-nav-item" href="{{ site.baseurl }}/">Research</a>
         </li>
         {% for tag_key in site.sidebar_tags %}
           {% assign tag = site.data.tags[tag_key] %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -28,7 +28,19 @@
     <nav class="sidebar-nav">
       <ul>
         <li>
+          <a class="sidebar-nav-item" href="{{ site.baseurl }}/about">About</a>
+        </li>
+        <li>
           <a class="sidebar-nav-item" href="{{ site.baseurl }}/">Research</a>
+        </li>
+        <li>
+          <a class="sidebar-nav-item" href="{{ site.baseurl }}/publications">Publications</a>
+        </li>
+        <li>
+          <a class="sidebar-nav-item" href="{{ site.baseurl }}/cv">CV</a>
+        </li>
+        <li>
+          <a class="sidebar-nav-item" href="{{ site.baseurl }}/photography">Photography</a>
         </li>
         {% for tag_key in site.sidebar_tags %}
           {% assign tag = site.data.tags[tag_key] %}
@@ -37,6 +49,9 @@
           </li>
         {% endfor %}
 
+        {% comment %}
+        UMN - activate the following section to enable auto-generation of the sidebar.
+        You'll lose control over the ordering of the sidebar elements.
         {% comment %}
           The code below dynamically generates a sidebar nav of pages with
           `layout: page` in the front-matter. See readme for usage.
@@ -52,6 +67,7 @@
             {% endif %}
           {% endif %}
         {% endfor %}
+        {% endcomment %}
       </ul>
     </nav>
 

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: Updates
+title: Research Updates
 ---
 
-<h1> Updates </h1>
+<h1> Research Updates </h1>
 <hr />
 
 {% for post in site.posts %}

--- a/photography/index.md
+++ b/photography/index.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Photography
+permalink: /photography/
+---
+
+Coming soon...
+
+
+For now, you can have a look at my [google fotos page][gfotos].
+
+
+[gfotos]: https://goo.gl/photos/9nmybVMtAB7u3aRG9

--- a/publications/index.md
+++ b/publications/index.md
@@ -37,9 +37,20 @@ permalink: /publications/
     ([ads link][pastorello2015aads], [journal link][pastorello2015ajournal])  
 
 
-## Conference Talks and Posters
+## Talks and Posters
 
-### Talks
+### Seminar Talks
+
+  * _SNe Ia within dense C/O envelopes: Potential explanation for superluminous SNe Ia_  
+    __Seminar Talk__, June 16, 2016, Oskar Klein Centre, Stockholm  
+
+  * _Radiation Hydrodynamical modelling in astrophysical outflows with Monte Carlo techniques_  
+    __Seminar Talk__, February 9, 2014, Max Planck Institute for Astrophysics, Garching  
+
+  * _Monte Carlo Radiation Hydrodynamics: Understanding Interacting Supernovae_  
+    __Seminar Talk__, July 13, 2012, Mount Stromlo Observatory, Canberra  
+
+### Conference Talks
 
   * _SNe Ia within dense C/O envelopes: A potential explanation for superluminous SNe Ia_  
     @__"18th Workshop on Nuclear Astrophysics"__, March 14 - 18, 2016, Ringberg Castle  
@@ -68,19 +79,12 @@ permalink: /publications/
   * Contributions to the  
     __9th, 8th, 6th, 4th, 3rd and 1st Wuerzburg Workshop on Supernovae and related topics__, 2011 - 2015, Universität Würzburg
 
-### Posters
+### Conference Posters
 
   * _Monte Carlo Radiation Hydrodynamics: Understanding Interacting Supernovae_  
     @ __"Supernovae Illuminating the Universe: from Individuals to Populations"__, MPA/ESO/MPE/Excellence Cluster Universe Conference, September 10 - 14, 2012, Garching  
     ([conference page][garching2012])
 
-## Seminar Talks
-
-  * _Radiation Hydrodynamical modelling in astrophysical outflows with Monte Carlo techniques_  
-    __Seminar Talk__, February 9, 2014, Max Planck Institute for Astrophysics  
-
-  * _Monte Carlo Radiation Hydrodynamics: Understanding Interacting Supernovae_  
-    __Seminar Talk__, July 13, 2012, Mount Stromlo Observatory  
 
 [noebauer2010ads]: http://adsabs.harvard.edu/abs/2010ApJ...719.1932N
 [noebauer2010journal]: http://iopscience.iop.org/0004-637X/719/2/1932/


### PR DESCRIPTION
This PR takes care of a number of small changes:
- the sidebar elements are no longer autogenerated (since there was no control over the ordering); instead they are manually added to the sidebar.html file
- updates are renamed to Research/Research Updates
- the OKC talk is added
- a photography page (almost empty for now, just a link to a google fotos album) is added
